### PR TITLE
Featur/init library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,124 @@
-# securebox
-securebox es una librería en Go para cifrado y descifrado seguro de datos sensibles. Usa AES-GCM o XChaCha20-Poly1305 con derivación de claves Argon2id, soporte de AAD, manejo de nonces (aleatorios o contadores) y versionado para rotación de claves. Ideal para integrarlo en backends.
+
+# Securebox
+
+Securebox is a Go library for secure encryption and decryption of sensitive data. It provides:
+
+- **AEAD ciphers:** AES-GCM and XChaCha20-Poly1305
+- **Key derivation:** Argon2id (password-based)
+- **Associated Authenticated Data (AAD):** Contextual data binding
+- **Nonce management:** Random or counter-based nonces
+- **Versioning:** For key rotation and future upgrades
+- **Password policy enforcement:** Strong password requirements
+
+## Installation
+
+Add Securebox to your Go project:
+
+```sh
+go get github.com/gabrieltorrealba/securebox
+```
+
+## Features
+
+- Encrypt and decrypt data using password-based keys
+- Support for AES-GCM and XChaCha20-Poly1305 AEAD ciphers
+- Argon2id for secure key derivation
+- Configurable nonce sources (random or auditable counter)
+- Associated Authenticated Data (AAD) for context binding
+- Strong password validation (min 12 chars, upper/lower/digit/symbol)
+- Custom error handling
+
+## Usage Example
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"github.com/gabrieltorrealba/securebox"
+	"github.com/gabrieltorrealba/securebox/aead"
+	"github.com/gabrieltorrealba/securebox/nonce"
+)
+
+func main() {
+	// Create a Box with AES-GCM and counter nonce
+	ns := nonce.NewCounter([4]byte{0xA1, 0xB2, 0xC3, 0xD4}, 0)
+	box := securebox.New(
+		securebox.WithAEAD(aead.NewAESGCM()),
+		securebox.WithNonceSource(ns),
+		securebox.WithPasswordValidation(true),
+	)
+
+	password := "SuperSecurePassword2025!"
+	aad := []byte("table=users;field=email;tenant=acme")
+	pii := []byte("DNI=12345678;Email=jhondoe@example.com")
+
+	enc, err := box.Encrypt(password, pii, aad)
+	if err != nil {
+		log.Fatal("Encrypt:", err)
+	}
+	fmt.Println("BLOB:", enc)
+
+	dec, err := box.Decrypt(password, enc, aad)
+	if err != nil {
+		log.Fatal("Decrypt:", err)
+	}
+	fmt.Println("Plain:", string(dec))
+
+	// Persist ns.Current() in your transactional storage
+	current := ns.Current()
+	fmt.Printf("Nonce Counter: %d\n", current)
+}
+```
+
+## API Overview
+
+### Box struct
+
+```go
+type Box struct {
+	AEAD        aead.AEAD         // AEAD cipher (AES-GCM or XChaCha20-Poly1305)
+	KDF         kdf.KDF           // Key Derivation Function (Argon2id)
+	NonceSource nonce.NonceSource // Nonce generator (random or counter)
+	ValidatePW  bool              // Enforce password validation
+}
+```
+
+### Creating a Box
+
+```go
+box := securebox.New(
+	securebox.WithAEAD(aead.NewAESGCM()),
+	securebox.WithKDF(kdf.NewArgon2id()),
+	securebox.WithNonceSource(nonce.NewRandom()),
+	securebox.WithPasswordValidation(true),
+)
+```
+
+### Encrypt
+
+```go
+enc, err := box.Encrypt(password, plaintext, aad)
+```
+- Returns a base64 string containing version, salt, nonce, and ciphertext.
+
+### Decrypt
+
+```go
+dec, err := box.Decrypt(password, encoded, aad)
+```
+- Returns the decrypted plaintext.
+
+### Password Policy
+
+- Minimum 12 characters
+- At least one uppercase, one lowercase, one digit, and one symbol
+
+## Error Handling
+
+Custom errors are provided for weak passwords, invalid base64, corrupt data, unsupported version, and decryption failures.
+
+## License
+
+MIT

--- a/aead/aead.go
+++ b/aead/aead.go
@@ -1,0 +1,17 @@
+package aead
+
+// AEAD represents an Authenticated Encryption with Associated Data cipher.
+// It provides methods for sealing (encrypting) and opening (decrypting) data
+// with authentication, using a symmetric key and a nonce.
+type AEAD interface {
+    // KeySize returns the key size in bytes required by the AEAD cipher.
+	KeySize() int
+    // NonceSize returns the nonce size in bytes required by the AEAD cipher.
+	NonceSize() int
+    // Seal encrypts and authenticates plaintext with the given key, nonce, and additional associated data (aad).
+    // It returns the resulting ciphertext, which includes the authentication tag.
+	Seal(key, nonce, plaintext, aad []byte) []byte
+    // Open decrypts and authenticates ciphertext with the given key, nonce, and additional associated data (aad).
+    // It returns the resulting plaintext if the authentication is successful; otherwise, it returns an error.
+	Open(key, nonce, ciphertext, aad []byte) ([]byte, error)
+}

--- a/aead/aesgcm.go
+++ b/aead/aesgcm.go
@@ -1,0 +1,44 @@
+package aead
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+)
+
+// aesgcm implements the AEAD interface using AES in Galois/Counter Mode (GCM).
+type aesgcm struct{}
+
+// NewAESGCM creates a new instance of AES-GCM AEAD.
+func NewAESGCM() AEAD { return &aesgcm{} }
+
+// AES-256 GCM uses a 32-byte (256-bit) key
+func (a *aesgcm) KeySize() int   { return 32 } 
+// AES GCM standard nonce size is 12 bytes (96 bits)
+func (a *aesgcm) NonceSize() int { return 12 } 
+
+// Seal encrypts and authenticates plaintext with the given key, nonce, and additional associated data (aad).
+// It returns the resulting ciphertext, which includes the authentication tag.
+func (a *aesgcm) Seal(key, nonce, plaintext, aad []byte) []byte {
+	block, _ := aes.NewCipher(key)
+	gcm, _ := cipher.NewGCMWithNonceSize(block, a.NonceSize())
+	return gcm.Seal(nil, nonce, plaintext, aad)
+}
+
+// Open decrypts and authenticates ciphertext with the given key, nonce, and additional associated data (aad).
+// It returns the resulting plaintext if the authentication is successful; otherwise, it returns an error.
+func (a *aesgcm) Open(key, nonce, ciphertext, aad []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCMWithNonceSize(block, a.NonceSize())
+	if err != nil {
+		return nil, err
+	}
+	pt, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, fmt.Errorf("gcm open: %w", err)
+	}
+	return pt, nil
+}

--- a/aead/xchacha.go
+++ b/aead/xchacha.go
@@ -1,0 +1,33 @@
+package aead
+
+import (
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// xchacha implements the XChaCha20-Poly1305 AEAD cipher.
+type xchacha struct{}
+
+// NewXChaCha20Poly1305 creates a new XChaCha20-Poly1305 AEAD instance.
+func NewXChaCha20Poly1305() AEAD { return &xchacha{} }
+
+// KeySize returns the key size in bytes for XChaCha20-Poly1305.
+func (x *xchacha) KeySize() int   { return chacha20poly1305.KeySize }
+// NonceSize returns the nonce size in bytes for XChaCha20-Poly1305.
+func (x *xchacha) NonceSize() int { return chacha20poly1305.NonceSizeX }
+
+// Seal encrypts and authenticates plaintext with the given key, nonce, and additional associated data (aad).
+// It returns the resulting ciphertext, which includes the authentication tag.
+func (x *xchacha) Seal(key, nonce, plaintext, aad []byte) []byte {
+	a, _ := chacha20poly1305.NewX(key)
+	return a.Seal(nil, nonce, plaintext, aad)
+}
+
+// Open decrypts and authenticates ciphertext with the given key, nonce, and additional associated data (aad).
+// It returns the resulting plaintext if the authentication is successful; otherwise, it returns an error.
+func (x *xchacha) Open(key, nonce, ciphertext, aad []byte) ([]byte, error) {
+	a, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, err
+	}
+	return a.Open(nil, nonce, ciphertext, aad)
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,11 @@
+package securebox
+
+import "errors"
+
+var (
+	ErrWeakPassword    = errors.New("password does not meet the minimum policy requirements")
+	ErrBadBase64       = errors.New("invalid base64 string")
+	ErrCorruptData     = errors.New("corrupt or incomplete data")
+	ErrUnsupportedVers = errors.New("unsupported version")
+	ErrDecryptFailed   = errors.New("decryption failed (incorrect key/nonce/salt/AAD or tampered data)")
+)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gabrieltorrealba/securebox"
+	"github.com/gabrieltorrealba/securebox/aead"
+	"github.com/gabrieltorrealba/securebox/nonce"
+)
+
+func main() {
+	// Choose AES-GCM with a counter nonce (auditable)
+	ns := nonce.NewCounter([4]byte{0xA1, 0xB2, 0xC3, 0xD4}, 0)
+	box := securebox.New(
+		securebox.WithAEAD(aead.NewAESGCM()),
+		securebox.WithNonceSource(ns),
+		securebox.WithPasswordValidation(true),
+	)
+
+	// Or Create a Box using XChaCha20-Poly1305 instead of AES-GCM
+	// box := securebox.New(
+	//   securebox.WithAEAD(aead.NewXChaCha20Poly1305()),
+	//)
+
+	password := "ClaveSúperSegura2025!"
+    // Contextual AAD (Associated Authenticated Data) can be nil
+	aad := []byte("table=users;field=email;tenant=acme")
+	pii := []byte("DNI=12345678;Email=jhondoe@example.com")
+
+	enc, err := box.Encrypt(password, pii, aad)
+	if err != nil {
+		log.Fatal("Encrypt:", err)
+	}
+	fmt.Println("BLOB:", enc)
+
+	dec, err := box.Decrypt(password, enc, aad)
+	if err != nil {
+		log.Fatal("Decrypt:", err)
+	}
+	fmt.Println("Plain:", string(dec))
+
+	// Persist ns.Current() in your transactional storage
+	current := ns.Current()
+    fmt.Printf("Nonce Counter: %d\n", current)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/gabrieltorrealba/securebox
+
+go 1.24.0
+
+require golang.org/x/crypto v0.42.0
+
+require golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
+golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/internal/pack.go
+++ b/internal/pack.go
@@ -1,0 +1,28 @@
+package internal
+
+import "fmt"
+
+// Pack concatenates version|salt|nonce|ciphertext
+// It returns the packed byte slice.
+func Pack(ver byte, salt, nonce, ct []byte) []byte {
+	out := make([]byte, 1+len(salt)+len(nonce)+len(ct))
+	out[0] = ver
+	copy(out[1:1+len(salt)], salt)
+	copy(out[1+len(salt):1+len(salt)+len(nonce)], nonce)
+	copy(out[1+len(salt)+len(nonce):], ct)
+	return out
+}
+
+// Unpack separates version|salt|nonce|ciphertext
+// It returns version, salt, nonce, ciphertext, error
+func Unpack(in []byte, nonceSize, saltSize int) (byte, []byte, []byte, []byte, error) {
+	min := 1 + saltSize + nonceSize
+	if len(in) < min {
+		return 0, nil, nil, nil, fmt.Errorf("insufficient data")
+	}
+	ver := in[0]
+	s := in[1 : 1+saltSize]
+	n := in[1+saltSize : 1+saltSize+nonceSize]
+	ct := in[1+saltSize+nonceSize:]
+	return ver, s, n, ct, nil
+}

--- a/internal/rand.go
+++ b/internal/rand.go
@@ -1,0 +1,11 @@
+package internal
+
+import "crypto/rand"
+
+// RandBytes generates a slice of n random bytes using crypto/rand.
+// It returns the byte slice and any error encountered.
+func RandBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	return b, err
+}

--- a/internal/validate.go
+++ b/internal/validate.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"unicode"
+
+	geterr "github.com/gabrieltorrealba/securebox/errors"
+)
+
+// ValidatePassword checks if the provided password meets the minimum security requirements.
+// Requirements:
+// - Minimum length of 12 characters
+// - At least one uppercase letter
+// - At least one lowercase letter
+// - At least one digit
+// - At least one symbol (punctuation or special character)
+// Returns an error if the password is weak, otherwise returns nil.
+func ValidatePassword(pw string) error {
+	if len(pw) < 12 {
+		return geterr.ErrWeakPassword
+	}
+	var hasUpper, hasLower, hasDigit, hasSymbol bool
+	for _, ch := range pw {
+		switch {
+		case unicode.IsUpper(ch):
+			hasUpper = true
+		case unicode.IsLower(ch):
+			hasLower = true
+		case unicode.IsDigit(ch):
+			hasDigit = true
+		case unicode.IsPunct(ch), unicode.IsSymbol(ch):
+			hasSymbol = true
+		}
+	}
+	if !hasUpper || !hasLower || !hasDigit || !hasSymbol {
+		return geterr.ErrWeakPassword
+	}
+	return nil
+}

--- a/kdf/argon2id.go
+++ b/kdf/argon2id.go
@@ -1,0 +1,25 @@
+package kdf
+
+import "golang.org/x/crypto/argon2"
+
+// argon2id implements the Argon2id key derivation function.
+type argon2id struct {
+	t    uint32
+	m    uint32
+	p    uint8
+	salt int
+}
+
+// NewArgon2id creates a new Argon2id KDF instance with default parameters.
+func NewArgon2id() KDF {
+	return &argon2id{t: 3, m: 64 * 1024, p: 4, salt: 16}
+}
+
+// SaltSize returns the salt size in bytes for Argon2id.
+func (a *argon2id) SaltSize() int { return a.salt }
+
+// Derive derives a key from the given password and salt using Argon2id.
+func (a *argon2id) Derive(password, salt []byte, outKeyLen int) ([]byte, error) {
+	key := argon2.IDKey(password, salt, a.t, a.m, a.p, uint32(outKeyLen))
+	return key, nil
+}

--- a/kdf/kdf.go
+++ b/kdf/kdf.go
@@ -1,0 +1,9 @@
+package kdf
+
+// KDF represents a Key Derivation Function.
+type KDF interface {
+    // SaltSize returns the size of the salt in bytes.
+	SaltSize() int
+    // Derive derives a key from the given password and salt.
+	Derive(password, salt []byte, outKeyLen int) ([]byte, error)
+}

--- a/nonce/counter.go
+++ b/nonce/counter.go
@@ -1,0 +1,43 @@
+package nonce
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+)
+
+// CounterSource: nonce = 4B prefix | 8B counter (big-endian)
+// It is NOT safe to use the same prefix in different instances
+// as it would lead to nonce reuse.
+type CounterSource struct {
+	Prefix  [4]byte
+	mu      sync.Mutex
+	Counter uint64
+}
+
+// NewCounter creates a new CounterSource with the given 4-byte prefix and starting counter value.
+func NewCounter(prefix [4]byte, start uint64) *CounterSource {
+	return &CounterSource{Prefix: prefix, Counter: start}
+}
+
+// Next generates the next nonce of the specified size.
+// It returns an error if the requested size is not 12 bytes.
+func (c *CounterSource) Next(size int) ([]byte, error) {
+	if size != 12 {
+		return nil, fmt.Errorf("CounterSource espera nonce de 12 bytes, got %d", size)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Counter++
+	n := make([]byte, 12)
+	copy(n[:4], c.Prefix[:])
+	binary.BigEndian.PutUint64(n[4:], c.Counter)
+	return n, nil
+}
+
+// Current returns the current counter value without incrementing it.
+func (c *CounterSource) Current() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.Counter
+}

--- a/nonce/nonce.go
+++ b/nonce/nonce.go
@@ -1,0 +1,7 @@
+package nonce
+
+// NonceSource represents a source of nonces.
+type NonceSource interface {
+    // Next generates the next nonce of the given size in bytes.
+	Next(size int) ([]byte, error)
+}

--- a/nonce/random.go
+++ b/nonce/random.go
@@ -1,0 +1,17 @@
+package nonce
+
+import "crypto/rand"
+
+
+// randomSource is a NonceSource that generates nonces using crypto/rand.
+type randomSource struct{}
+
+// NewRandom creates a new NonceSource that generates random nonces.
+func NewRandom() NonceSource { return &randomSource{} }
+
+// Next generates the next nonce of the given size in bytes.
+func (randomSource) Next(size int) ([]byte, error) {
+	b := make([]byte, size)
+	_, err := rand.Read(b)
+	return b, err
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,22 @@
+package securebox
+
+import (
+	"github.com/gabrieltorrealba/securebox/aead"
+	"github.com/gabrieltorrealba/securebox/kdf"
+	"github.com/gabrieltorrealba/securebox/nonce"
+)
+
+// Option defines a configuration option for the Box.
+type Option func(*Box)
+
+// WithAEAD sets the AEAD implementation to use.
+func WithAEAD(x aead.AEAD) Option { return func(b *Box) { b.AEAD = x } }
+
+// WithKDF sets the KDF implementation to use.
+func WithKDF(x kdf.KDF) Option { return func(b *Box) { b.KDF = x } }
+
+// WithNonceSource sets the NonceSource implementation to use.
+func WithNonceSource(ns nonce.NonceSource) Option { return func(b *Box) { b.NonceSource = ns } }
+
+// WithPasswordValidation enables or disables password validation.
+func WithPasswordValidation(v bool) Option { return func(b *Box) { b.ValidatePW = v } }

--- a/securebox.go
+++ b/securebox.go
@@ -1,0 +1,103 @@
+package securebox
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gabrieltorrealba/securebox/aead"
+	adderr "github.com/gabrieltorrealba/securebox/errors"
+	"github.com/gabrieltorrealba/securebox/internal"
+	"github.com/gabrieltorrealba/securebox/kdf"
+	"github.com/gabrieltorrealba/securebox/nonce"
+)
+
+const versionByte byte = 0x01
+
+// Box provides methods to encrypt and decrypt data using password-based encryption.
+type Box struct {
+	// AEAD is the Authenticated Encryption with Associated Data cipher to use.
+	AEAD aead.AEAD
+	// KDF is the Key Derivation Function to use.
+	KDF kdf.KDF
+	// NonceSource is the source of nonces to use.
+	NonceSource nonce.NonceSource
+	// ValidatePW indicates whether to enforce password validation.
+	ValidatePW bool
+}
+
+// New creates a new Box with the provided options.
+// It sets default implementations for AEAD (AES-GCM), KDF (Argon2id), and NonceSource (random nonces).
+// The ValidatePW option is enabled by default.
+func New(opts ...Option) *Box {
+	b := &Box{
+		AEAD:        aead.NewAESGCM(),
+		KDF:         kdf.NewArgon2id(),
+		NonceSource: nonce.NewRandom(),
+		ValidatePW:  true,
+	}
+	for _, o := range opts {
+		o(b)
+	}
+	return b
+}
+
+// Encrypt => base64(version|salt|nonce|ciphertext)
+// It returns the encrypted data as a base64-encoded string or an error if encryption fails.
+func (b *Box) Encrypt(password string, plaintext, aad []byte) (string, error) {
+	if b.ValidatePW {
+		if err := internal.ValidatePassword(password); err != nil {
+			return "", err
+		}
+	}
+
+	salt := b.KDF.SaltSize()
+	s, err := internal.RandBytes(salt)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := b.KDF.Derive([]byte(password), s, b.AEAD.KeySize())
+	if err != nil {
+		return "", err
+	}
+
+	n, err := b.NonceSource.Next(b.AEAD.NonceSize())
+	if err != nil {
+		return "", err
+	}
+	if len(n) != b.AEAD.NonceSize() {
+		return "", fmt.Errorf("nonce size mismatch: got %d want %d", len(n), b.AEAD.NonceSize())
+	}
+
+	ct := b.AEAD.Seal(key, n, plaintext, aad)
+	pkg := internal.Pack(versionByte, s, n, ct)
+	return base64.StdEncoding.EncodeToString(pkg), nil
+}
+
+// Decrypt => base64(version|salt|nonce|ciphertext)
+// It returns the decrypted plaintext or an error if decryption fails.
+func (b *Box) Decrypt(password, encoded string, aad []byte) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, adderr.ErrBadBase64
+	}
+
+	ver, s, n, ct, err := internal.Unpack(raw, b.AEAD.NonceSize(), b.KDF.SaltSize())
+	if err != nil {
+		return nil, err
+	}
+	if ver != versionByte {
+		return nil, adderr.ErrUnsupportedVers
+	}
+
+	key, err := b.KDF.Derive([]byte(password), s, b.AEAD.KeySize())
+	if err != nil {
+		return nil, err
+	}
+
+	pt, err := b.AEAD.Open(key, n, ct, aad)
+	if err != nil {
+		return nil, adderr.ErrDecryptFailed
+	}
+	return pt, nil
+}

--- a/tests/aad_test.go
+++ b/tests/aad_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gabrieltorrealba/securebox"
+)
+
+func TestAADMismatchFails(t *testing.T) {
+	box := securebox.New()
+	pw := "ClaveSúperSegura2025!"
+	msg := []byte("hola mundo")
+
+	enc, err := box.Encrypt(pw, msg, []byte("A"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := box.Decrypt(pw, enc, []byte("B")); err == nil {
+		t.Fatal("expected error with AAD mismatch")
+	}
+}

--- a/tests/encrypt_decrypt_test.go
+++ b/tests/encrypt_decrypt_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/gabrieltorrealba/securebox"
+)
+
+func TestEncryptDecrypt_Random(t *testing.T) {
+	box := securebox.New()
+	pw := "ClaveSúperSegura2025!"
+	aad := []byte("ctx")
+	msg := []byte("hola mundo")
+
+	enc, err := box.Encrypt(pw, msg, aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec, err := box.Decrypt(pw, enc, aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(dec) != string(msg) {
+		t.Fatalf("got %q want %q", dec, msg)
+	}
+}


### PR DESCRIPTION
Added comprehensive English documentation to [README.md](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), covering installation, features, usage, API overview, password policy, error handling, and license.

Initial app setup: added all core library files, including AEAD ciphers (AES-GCM, XChaCha20-Poly1305), key derivation (Argon2id), nonce management, error handling, options, main API (Box), example usage, and tests.